### PR TITLE
added a static refresh_flag that is set to 1 at the start of the refr…

### DIFF
--- a/VarSpeedServo.h
+++ b/VarSpeedServo.h
@@ -114,7 +114,7 @@ typedef enum { _timer1, _Nbr_16timers } timer16_Sequence_t ;
 
 #define VarSpeedServo_VERSION           2      // software version of this library
 
-#define MIN_PULSE_WIDTH       544     // the shortest pulse sent to a servo  
+#define MIN_PULSE_WIDTH       444     // the shortest pulse sent to a servo  
 #define MAX_PULSE_WIDTH      2400     // the longest pulse sent to a servo 
 #define DEFAULT_PULSE_WIDTH  1500     // default pulse width when servo is attached
 #define REFRESH_INTERVAL    20000     // minumim time to refresh servos in microseconds 
@@ -147,6 +147,7 @@ typedef struct {
 class VarSpeedServo
 {
 public:
+  static volatile int8_t refresh_flag;
   VarSpeedServo();
   uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
   uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes. 


### PR DESCRIPTION
…esh period and is set to 0 when it ends.

This can be used to signal a "calm" period when the servos values can be updated.

(Also changed the lowest value for a servo pulse in us because some of my servos needed that for the full range)
