### PR TITLE
Fix initial move of servo motor

### DIFF
--- a/VarSpeedServo.cpp
+++ b/VarSpeedServo.cpp
@@ -301,7 +301,7 @@ VarSpeedServo::VarSpeedServo()
 {
   if( ServoCount < MAX_SERVOS) {
     this->servoIndex = ServoCount++;                    // assign a servo index to this instance
-	  servos[this->servoIndex].ticks = usToTicks(DEFAULT_PULSE_WIDTH);   // store default values  - 12 Aug 2009
+    servos[this->servoIndex].ticks = 0;   // store default values  - 12 Aug 2009
     this->curSeqPosition = 0;
     this->curSequence = initSeq;
   }
@@ -316,7 +316,13 @@ uint8_t VarSpeedServo::attach(int pin)
 
 uint8_t VarSpeedServo::attach(int pin, int min, int max)
 {
+  return this->attach(pin, min, max, DEFAULT_PULSE_WIDTH);
+}
+
+uint8_t VarSpeedServo::attach(int pin, int min, int max, int initialPulseWidth)
+{
   if(this->servoIndex < MAX_SERVOS ) {
+    servos[this->servoIndex].ticks = usToTicks(initialPulseWidth);
     pinMode( pin, OUTPUT) ;                                   // set servo pin to output
     servos[this->servoIndex].Pin.nbr = pin;
     // todo min/max check: abs(min - MIN_PULSE_WIDTH) /4 < 128

--- a/VarSpeedServo.h
+++ b/VarSpeedServo.h
@@ -151,6 +151,8 @@ public:
   VarSpeedServo();
   uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
   uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes.
+  uint8_t attach(int pin, int min, int max, int initialPulseWidth); // as above but also sets initial pulse width.
+          // If you set 0, servo dose not move from initial position.
   void detach();
   void write(int value);             // if value is < 544 its treated as an angle, otherwise as pulse width in microseconds
   void write(int value, uint8_t speed); // Move to given position at reduced speed.


### PR DESCRIPTION
This PR would fix the problem which is reported in #14 .
I guess that it makes same initial move as Servo library
and this could also avoid initial movement with `.attach(...,0)`
which would be new feature.
And it would also close #25 #26 .

This PR changes the initial state of servo.ticks and 
I have not tested this PR yet, because I don't have servo motor, sorry.
Thus, it might be better to apply this PR after someone's test report.
I create this PR with reference to https://stackoverflow.com/questions/40892922/.

And I am not good at English, thus, if you know better English words,
please fix variable name and comments.