### PR TITLE
Removed default pulse width

### DIFF
--- a/VarSpeedServo.cpp
+++ b/VarSpeedServo.cpp
@@ -301,7 +301,6 @@ VarSpeedServo::VarSpeedServo()
 {
   if( ServoCount < MAX_SERVOS) {
     this->servoIndex = ServoCount++;                    // assign a servo index to this instance
-	  servos[this->servoIndex].ticks = usToTicks(DEFAULT_PULSE_WIDTH);   // store default values  - 12 Aug 2009
     this->curSeqPosition = 0;
     this->curSequence = initSeq;
   }

--- a/VarSpeedServo.h
+++ b/VarSpeedServo.h
@@ -116,7 +116,7 @@ typedef enum { _timer1, _Nbr_16timers } timer16_Sequence_t ;
 
 #define MIN_PULSE_WIDTH       544     // the shortest pulse sent to a servo
 #define MAX_PULSE_WIDTH      2400     // the longest pulse sent to a servo
-#define DEFAULT_PULSE_WIDTH  1500     // default pulse width when servo is attached
+
 #define REFRESH_INTERVAL    20000     // minimum time to refresh servos in microseconds
 
 #define SERVOS_PER_TIMER       12     // the maximum number of servos controlled by one timer


### PR DESCRIPTION
This deafult pulse width is not good for some servos as Mg995 shows bad behaviour(while going to new position everytime, it first go to default position).This may result in damaging this servo motor.Almost 10-12 servos are damaged in our case.